### PR TITLE
Add initFromDate

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -1,5 +1,5 @@
 module DatePicker exposing
-    ( Msg(..), init, update, Model
+    ( Msg(..), init, initFromDate, update, Model
     , view, Props, defaultProps
     , setIndexDate
     , SelectionMode
@@ -213,6 +213,23 @@ init id =
       }
     , Task.perform GetToday Date.today
     )
+
+
+{-| Initialize a date picker given a date to start from.
+-}
+initFromDate : String -> Date -> Model
+initFromDate id date =
+    setIndexDate { id = id
+    , today = Just date
+    , indexDate = Nothing
+    , currentMonthMap = Nothing
+    , previousMonthMap = Nothing
+    , selectedDate = Nothing
+    , previousSelectedDate = Nothing
+    , monthChange = None
+    , selectionMode = Calendar
+    , yearList = Just (defaultedYearList Nothing date)
+    } date
 
 
 {-| Use `DatePicker.update` to create updated date picker models from any message events.

--- a/src/Demo.elm
+++ b/src/Demo.elm
@@ -3,6 +3,7 @@ module Demo exposing (Model, Msg(..), init, main, subscriptions, update, view)
 import Browser
 import Date exposing (..)
 import DatePicker exposing (Msg(..))
+import Time exposing (Month(..))
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -33,6 +34,18 @@ init flags =
       , selectedDate = Nothing
       }
     , Cmd.map DatePickerMsg datePickerCmd
+    )
+
+initFromApolloLanding : Flags -> ( Model, Cmd Msg )
+initFromApolloLanding flags =
+    let
+        datePickerData =
+            DatePicker.initFromDate "my-datepicker" (fromCalendarDate 1969 Jul 20)
+    in
+    ( { datePickerData = datePickerData
+      , selectedDate = Nothing
+      }
+    , Cmd.none
     )
 
 


### PR DESCRIPTION
This allows a user to provide the date shown at first in the
datepicker. This could be useful to edit existing dates or perhaps
because the developer already knows what day it is.

You can test it by changing `init` to `initFromApolloLanding` in Demo.elm.